### PR TITLE
Implement basic instrument refresh and subscription persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,24 @@ For more details, see the comments in `application.properties` and `.env.example
 An endpoint `/api/instruments/{exchange}` downloads the instrument CSV from Kite
 and stores it in the configured Postgres database. Invoke it with a POST request
 and provide exchanges like `nse`, `bse`, `bfo`, etc. Additional GET endpoints
-`/api/instruments/exchanges` and `/api/instruments/names` expose stored
-exchanges and instrument names for populating UI drop-downs.
+`/api/instruments/exchanges`, `/api/instruments/types?exchange=NSE` and
+`/api/instruments/names?exchange=NSE&type=EQ` expose stored exchange,
+instrument types and instrument names for populating UI drop-downs.
 
 ## WebSocket Streaming
 
-The application exposes `/api/ticker/subscribe` and `/api/ticker/disconnect` REST
-endpoints which delegate to `KiteTickerService`. The service opens a WebSocket
-connection to Kite using the `kite_access_token` stored in the session. Ticks
-received from the stream are currently printed to the console.
+The application exposes `/api/ticker/subscribe`, `/api/ticker/subscriptions` and
+`/api/ticker/disconnect` REST endpoints. Subscribing persists the tokens in the
+`subscriptions` table and forwards them to the WebSocket via `KiteTickerService`.
+The service opens a WebSocket connection to Kite using the
+`kite_access_token` stored in the session. Ticks received from the stream are
+currently printed to the console.
+
+### Placing Orders
+
+Orders can be placed via the `/api/orders` REST endpoint. Provide a JSON body with
+`tradingsymbol`, `exchange`, `transactionType`, `quantity` and optional `price`.
+Placed orders are stored in the `trade_orders` table for later analysis.
 
 Swagger documentation is available once the application is running at
 `http://localhost:8080/swagger-ui.html`.

--- a/src/main/java/org/mandrin/rain/broker/config/ApiConstants.java
+++ b/src/main/java/org/mandrin/rain/broker/config/ApiConstants.java
@@ -2,10 +2,13 @@ package org.mandrin.rain.broker.config;
 
 public class ApiConstants {
     public static final String HOLDINGS_URL = "https://api.kite.trade/portfolio/holdings";
+    public static final String ORDER_URL = "https://api.kite.trade/orders/regular";
     public static final String KITE_VERSION_HEADER = "X-Kite-Version";
     public static final String KITE_VERSION = "3";
     public static final String AUTH_HEADER = "Authorization";
     public static final String AUTH_TOKEN_FORMAT = "token %s:%s";
+    public static final String ORDER_TYPE_MARKET = "MARKET";
+    public static final String PRODUCT_MIS = "MIS";
     public static final String STATUS_SUCCESS = "success";
     public static final String STATUS_ERROR = "error";
     public static final String NOT_AUTHENTICATED_MSG = "Not authenticated";

--- a/src/main/java/org/mandrin/rain/broker/controller/AuthController.java
+++ b/src/main/java/org/mandrin/rain/broker/controller/AuthController.java
@@ -1,20 +1,21 @@
 package org.mandrin.rain.broker.controller;
 
-import com.zerodhatech.kiteconnect.kitehttp.exceptions.KiteException;
 import jakarta.servlet.http.HttpSession;
 import org.mandrin.rain.broker.service.KiteAuthService;
 import org.mandrin.rain.broker.config.KiteConstants;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 public class AuthController {
-    @Autowired
-    private KiteAuthService kiteAuthService;
+    private final KiteAuthService kiteAuthService;
 
     @GetMapping(KiteConstants.KITE_LOGIN_PATH)
     public String login() {
@@ -26,11 +27,14 @@ public class AuthController {
         try {
             kiteAuthService.getAccessToken(requestToken, session);
             return "redirect:" + KiteConstants.HOME_PATH;
+        } catch (com.zerodhatech.kiteconnect.kitehttp.exceptions.KiteException e) {
+            log.error("Kite API error", e);
+            redirectAttributes.addFlashAttribute("error", "Kite error: " + e.getMessage());
+            return "redirect:/error";
         } catch (Exception e) {
+            log.error("Authentication failed", e);
             redirectAttributes.addFlashAttribute("error", "Authentication failed: " + e.getMessage());
             return "redirect:/error";
-        } catch (KiteException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/mandrin/rain/broker/controller/GlobalExceptionHandler.java
+++ b/src/main/java/org/mandrin/rain/broker/controller/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package org.mandrin.rain.broker.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleException(Exception ex) {
+        log.error("Unhandled exception", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", ex.getMessage()));
+    }
+}

--- a/src/main/java/org/mandrin/rain/broker/controller/InstrumentController.java
+++ b/src/main/java/org/mandrin/rain/broker/controller/InstrumentController.java
@@ -2,13 +2,15 @@ package org.mandrin.rain.broker.controller;
 
 import org.mandrin.rain.broker.model.Instrument;
 import org.mandrin.rain.broker.service.InstrumentService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.List;
@@ -16,34 +18,42 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/instruments")
+@RequiredArgsConstructor
+@Slf4j
 public class InstrumentController {
     private final InstrumentService instrumentService;
 
-    @Autowired
-    public InstrumentController(InstrumentService instrumentService) {
-        this.instrumentService = instrumentService;
-    }
-
     @PostMapping("/{exchange}")
     public ResponseEntity<?> load(@PathVariable String exchange) throws IOException {
+        log.info("Loading instruments for {}", exchange);
         List<Instrument> list = instrumentService.fetchAndSave(exchange);
         return ResponseEntity.ok(Map.of("saved", list.size()));
     }
 
     @GetMapping("/exchanges")
     public List<String> exchanges() {
-        return instrumentService.listExchanges();
+        List<String> list = instrumentService.listExchanges();
+        log.debug("exchanges -> {}", list);
+        return list;
     }
 
     @GetMapping("/names")
-    public List<Map<String, Object>> names() {
+    public List<Map<String, Object>> names(@RequestParam String exchange, @RequestParam String type) {
+        log.info("Fetching instrument names for {} {}", exchange, type);
         List<Map<String, Object>> result = new java.util.ArrayList<>();
-        for (var v : instrumentService.listNameTokens()) {
+        for (var v : instrumentService.listNames(exchange, type)) {
             Map<String, Object> m = new java.util.HashMap<>();
             m.put("instrumentToken", v.getInstrumentToken());
             m.put("name", v.getName());
             result.add(m);
         }
         return result;
+    }
+
+    @GetMapping("/types")
+    public List<String> types(@RequestParam String exchange) {
+        List<String> list = instrumentService.listInstrumentTypes(exchange);
+        log.debug("types for {} -> {}", exchange, list);
+        return list;
     }
 }

--- a/src/main/java/org/mandrin/rain/broker/controller/OrderController.java
+++ b/src/main/java/org/mandrin/rain/broker/controller/OrderController.java
@@ -1,0 +1,33 @@
+package org.mandrin.rain.broker.controller;
+
+import jakarta.servlet.http.HttpSession;
+import org.mandrin.rain.broker.model.TradeOrder;
+import org.mandrin.rain.broker.service.OrderService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+@Slf4j
+public class OrderController {
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<?> place(@RequestBody TradeOrder req, HttpSession session) {
+        log.info("/orders POST received for {}", req.getTradingsymbol());
+        TradeOrder saved = orderService.placeOrder(session, req);
+        return ResponseEntity.ok(saved);
+    }
+
+    @GetMapping
+    public List<TradeOrder> list() {
+        List<TradeOrder> list = orderService.listOrders();
+        log.debug("/orders GET returned {} entries", list.size());
+        return list;
+    }
+}

--- a/src/main/java/org/mandrin/rain/broker/controller/PortfolioController.java
+++ b/src/main/java/org/mandrin/rain/broker/controller/PortfolioController.java
@@ -3,7 +3,6 @@ package org.mandrin.rain.broker.controller;
 import jakarta.servlet.http.HttpSession;
 import org.mandrin.rain.broker.config.ApiConstants;
 import org.mandrin.rain.broker.config.KiteConstants;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -11,23 +10,23 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/portfolio")
+@RequiredArgsConstructor
+@Slf4j
 public class PortfolioController {
     @Value("${kite.api_key}")
     private String apiKey;
 
     private final RestTemplate restTemplate;
 
-    @Autowired
-    public PortfolioController(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
-    }
-
     @GetMapping("/holdings")
     public ResponseEntity<?> getHoldings(HttpSession session) {
+        log.info("Fetching portfolio holdings");
         String accessToken = (String) session.getAttribute(KiteConstants.KITE_ACCESS_TOKEN_SESSION);
         if (accessToken == null) {
             return ResponseEntity.status(401).body(Map.of("status", ApiConstants.STATUS_ERROR, "message", ApiConstants.NOT_AUTHENTICATED_MSG));

--- a/src/main/java/org/mandrin/rain/broker/model/Instrument.java
+++ b/src/main/java/org/mandrin/rain/broker/model/Instrument.java
@@ -3,10 +3,14 @@ package org.mandrin.rain.broker.model;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "instruments")
+@Data
+@NoArgsConstructor
 public class Instrument {
     @Id
     private Long instrumentToken;
@@ -21,78 +25,4 @@ public class Instrument {
     private String instrumentType;
     private String segment;
     private String exchange;
-
-    // getters and setters
-    public Long getInstrumentToken() {
-        return instrumentToken;
-    }
-    public void setInstrumentToken(Long instrumentToken) {
-        this.instrumentToken = instrumentToken;
-    }
-    public Long getExchangeToken() {
-        return exchangeToken;
-    }
-    public void setExchangeToken(Long exchangeToken) {
-        this.exchangeToken = exchangeToken;
-    }
-    public String getTradingsymbol() {
-        return tradingsymbol;
-    }
-    public void setTradingsymbol(String tradingsymbol) {
-        this.tradingsymbol = tradingsymbol;
-    }
-    public String getName() {
-        return name;
-    }
-    public void setName(String name) {
-        this.name = name;
-    }
-    public Double getLastPrice() {
-        return lastPrice;
-    }
-    public void setLastPrice(Double lastPrice) {
-        this.lastPrice = lastPrice;
-    }
-    public LocalDate getExpiry() {
-        return expiry;
-    }
-    public void setExpiry(LocalDate expiry) {
-        this.expiry = expiry;
-    }
-    public Double getStrike() {
-        return strike;
-    }
-    public void setStrike(Double strike) {
-        this.strike = strike;
-    }
-    public Double getTickSize() {
-        return tickSize;
-    }
-    public void setTickSize(Double tickSize) {
-        this.tickSize = tickSize;
-    }
-    public Integer getLotSize() {
-        return lotSize;
-    }
-    public void setLotSize(Integer lotSize) {
-        this.lotSize = lotSize;
-    }
-    public String getInstrumentType() {
-        return instrumentType;
-    }
-    public void setInstrumentType(String instrumentType) {
-        this.instrumentType = instrumentType;
-    }
-    public String getSegment() {
-        return segment;
-    }
-    public void setSegment(String segment) {
-        this.segment = segment;
-    }
-    public String getExchange() {
-        return exchange;
-    }
-    public void setExchange(String exchange) {
-        this.exchange = exchange;
-    }
 }

--- a/src/main/java/org/mandrin/rain/broker/model/Subscription.java
+++ b/src/main/java/org/mandrin/rain/broker/model/Subscription.java
@@ -1,0 +1,20 @@
+package org.mandrin.rain.broker.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "subscriptions", uniqueConstraints = @UniqueConstraint(columnNames = "instrument_token"))
+@Data
+@NoArgsConstructor
+public class Subscription {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "instrument_token", nullable = false)
+    private Long instrumentToken;
+    private String tradingsymbol;
+    private LocalDateTime subscribedAt;
+}

--- a/src/main/java/org/mandrin/rain/broker/model/TradeOrder.java
+++ b/src/main/java/org/mandrin/rain/broker/model/TradeOrder.java
@@ -1,0 +1,24 @@
+package org.mandrin.rain.broker.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trade_orders")
+@Data
+@NoArgsConstructor
+public class TradeOrder {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long instrumentToken;
+    private String tradingsymbol;
+    private String exchange;
+    private String transactionType;
+    private Integer quantity;
+    private Double price;
+    private String orderId;
+    private LocalDateTime placedAt;
+}

--- a/src/main/java/org/mandrin/rain/broker/repository/InstrumentRepository.java
+++ b/src/main/java/org/mandrin/rain/broker/repository/InstrumentRepository.java
@@ -17,4 +17,10 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
 
     @Query("select i.instrumentToken as instrumentToken, i.name as name from Instrument i")
     List<NameTokenView> findNameTokenAll();
+
+    @Query("select distinct i.instrumentType from Instrument i where i.exchange = :exchange")
+    List<String> findDistinctInstrumentType(String exchange);
+
+    @Query("select i.instrumentToken as instrumentToken, i.name as name from Instrument i where i.exchange = :exchange and i.instrumentType = :type")
+    List<NameTokenView> findNameToken(String exchange, String type);
 }

--- a/src/main/java/org/mandrin/rain/broker/repository/SubscriptionRepository.java
+++ b/src/main/java/org/mandrin/rain/broker/repository/SubscriptionRepository.java
@@ -1,0 +1,8 @@
+package org.mandrin.rain.broker.repository;
+
+import org.mandrin.rain.broker.model.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+    boolean existsByInstrumentToken(Long instrumentToken);
+}

--- a/src/main/java/org/mandrin/rain/broker/repository/TradeOrderRepository.java
+++ b/src/main/java/org/mandrin/rain/broker/repository/TradeOrderRepository.java
@@ -1,0 +1,7 @@
+package org.mandrin.rain.broker.repository;
+
+import org.mandrin.rain.broker.model.TradeOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeOrderRepository extends JpaRepository<TradeOrder, Long> {
+}

--- a/src/main/java/org/mandrin/rain/broker/service/KiteTickerService.java
+++ b/src/main/java/org/mandrin/rain/broker/service/KiteTickerService.java
@@ -5,9 +5,7 @@ import jakarta.servlet.http.HttpSession;
 import org.mandrin.rain.broker.config.KiteConstants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +17,8 @@ import java.util.List;
  * subscribe to instrument tokens.
  */
 @Service
+@Slf4j
 public class KiteTickerService {
-    private static final Logger logger = LogManager.getLogger(KiteTickerService.class);
     
     @Value("${kite.api_key}")
     private String apiKey;
@@ -37,11 +35,11 @@ public class KiteTickerService {
     private synchronized KiteTicker getOrCreateTicker(String accessToken) {
         if (kiteTicker == null || !kiteTicker.isConnectionOpen()) {
             kiteTicker = new KiteTicker(apiKey, accessToken);
-            kiteTicker.setOnConnectedListener(() -> logger.info("KiteTicker connected"));
-            kiteTicker.setOnDisconnectedListener(() -> logger.info("KiteTicker disconnected"));
+            kiteTicker.setOnConnectedListener(() -> log.info("KiteTicker connected"));
+            kiteTicker.setOnDisconnectedListener(() -> log.info("KiteTicker disconnected"));
             kiteTicker.setOnTickerArrivalListener(ticks -> {
                 for (var tick : ticks) {
-                    logger.info("Tick: {}", tick);
+                    log.info("Tick: {}", tick);
                 }
             });
             kiteTicker.connect();
@@ -74,6 +72,7 @@ public class KiteTickerService {
     public void subscribe(HttpSession session, List<Long> tokens) {
         connect(session);
         ArrayList<Long> list = new ArrayList<>(tokens);
+        log.info("Subscribing to {} instruments", list.size());
         kiteTicker.subscribe(list);
         kiteTicker.setMode(list, KiteTicker.modeFull);
     }
@@ -83,6 +82,7 @@ public class KiteTickerService {
      */
     public void disconnect() {
         if (kiteTicker != null) {
+            log.info("Disconnecting ticker");
             kiteTicker.disconnect();
         }
     }

--- a/src/main/java/org/mandrin/rain/broker/service/OrderService.java
+++ b/src/main/java/org/mandrin/rain/broker/service/OrderService.java
@@ -1,0 +1,83 @@
+package org.mandrin.rain.broker.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.mandrin.rain.broker.config.ApiConstants;
+import org.mandrin.rain.broker.config.KiteConstants;
+import org.mandrin.rain.broker.model.TradeOrder;
+import org.mandrin.rain.broker.repository.TradeOrderRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderService {
+    @Value("${kite.api_key}")
+    private String apiKey;
+
+    private final WebClient webClient;
+    private final TradeOrderRepository repository;
+
+    /**
+     * Place an order using Kite Connect and persist the details.
+     */
+    public TradeOrder placeOrder(HttpSession session, TradeOrder req) {
+        log.info("Placing order for {} qty {}", req.getTradingsymbol(), req.getQuantity());
+        String accessToken = (String) session.getAttribute(KiteConstants.KITE_ACCESS_TOKEN_SESSION);
+        if (accessToken == null) {
+            throw new IllegalStateException(ApiConstants.NOT_AUTHENTICATED_MSG);
+        }
+        String url = ApiConstants.ORDER_URL;
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(ApiConstants.KITE_VERSION_HEADER, ApiConstants.KITE_VERSION);
+        headers.set(ApiConstants.AUTH_HEADER,
+                String.format(ApiConstants.AUTH_TOKEN_FORMAT, apiKey, accessToken));
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("tradingsymbol", req.getTradingsymbol());
+        body.add("exchange", req.getExchange());
+        body.add("transaction_type", req.getTransactionType());
+        body.add("quantity", String.valueOf(req.getQuantity()));
+        if (req.getPrice() != null) {
+            body.add("price", String.valueOf(req.getPrice()));
+        }
+        body.add("order_type", ApiConstants.ORDER_TYPE_MARKET);
+        body.add("product", ApiConstants.PRODUCT_MIS);
+
+        Mono<Map> mono = webClient.post()
+                .uri(url)
+                .headers(h -> {
+                    h.addAll(headers);
+                    h.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                })
+                .body(BodyInserters.fromFormData(body))
+                .retrieve()
+                .bodyToMono(Map.class);
+        Map resp = mono.block();
+        if (resp != null && resp.containsKey("data")) {
+            Object data = ((Map) resp.get("data")).get("order_id");
+            req.setOrderId(data != null ? data.toString() : null);
+        }
+        req.setPlacedAt(LocalDateTime.now());
+        TradeOrder saved = repository.save(req);
+        log.info("Order saved with id {} and orderId {}", saved.getId(), saved.getOrderId());
+        return saved;
+    }
+
+    public java.util.List<TradeOrder> listOrders() {
+        java.util.List<TradeOrder> list = repository.findAll();
+        log.debug("listOrders -> {}", list.size());
+        return list;
+    }
+}

--- a/src/main/java/org/mandrin/rain/broker/service/SubscriptionService.java
+++ b/src/main/java/org/mandrin/rain/broker/service/SubscriptionService.java
@@ -1,0 +1,41 @@
+package org.mandrin.rain.broker.service;
+
+import org.mandrin.rain.broker.model.Subscription;
+import org.mandrin.rain.broker.repository.InstrumentRepository;
+import org.mandrin.rain.broker.repository.SubscriptionRepository;
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionService {
+    private final SubscriptionRepository repository;
+    private final InstrumentRepository instrumentRepository;
+
+    public void saveAll(List<Long> tokens) {
+        for (Long t : tokens) {
+            if (!repository.existsByInstrumentToken(t)) {
+                Subscription s = new Subscription();
+                s.setInstrumentToken(t);
+                instrumentRepository.findById(t).ifPresent(i -> s.setTradingsymbol(i.getTradingsymbol()));
+                s.setSubscribedAt(LocalDateTime.now());
+                repository.save(s);
+                log.info("Subscribed instrument {}", t);
+            } else {
+                log.debug("Instrument {} already subscribed", t);
+            }
+        }
+    }
+
+    public List<Long> listTokens() {
+        List<Long> list = repository.findAll().stream().map(Subscription::getInstrumentToken).collect(Collectors.toList());
+        log.debug("listTokens -> {}", list);
+        return list;
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,14 +1,5 @@
 -- NOTE: This schema file does not create the database. Please ensure the database exists before running these statements.
-CREATE DATABASE "BROKER_ZERODHA_ONLINE_DB"
-    WITH
-    OWNER = postgres
-    ENCODING = 'UTF8'
-    LC_COLLATE = 'C'
-    LC_CTYPE = 'C'
-    LOCALE_PROVIDER = 'libc'
-    TABLESPACE = pg_default
-    CONNECTION LIMIT = -1
-    IS_TEMPLATE = False;
+
 
 CREATE TABLE IF NOT EXISTS instruments (
     instrument_token BIGINT PRIMARY KEY,
@@ -23,4 +14,23 @@ CREATE TABLE IF NOT EXISTS instruments (
     instrument_type VARCHAR(20),
     segment VARCHAR(20),
     exchange VARCHAR(20)
+);
+
+CREATE TABLE IF NOT EXISTS trade_orders (
+    id SERIAL PRIMARY KEY,
+    instrument_token BIGINT,
+    tradingsymbol VARCHAR(50),
+    exchange VARCHAR(20),
+    transaction_type VARCHAR(10),
+    quantity INTEGER,
+    price DOUBLE PRECISION,
+    order_id VARCHAR(50),
+    placed_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id SERIAL PRIMARY KEY,
+    instrument_token BIGINT UNIQUE,
+    tradingsymbol VARCHAR(50),
+    subscribed_at TIMESTAMP
 );

--- a/src/main/resources/static/js/instruments.js
+++ b/src/main/resources/static/js/instruments.js
@@ -1,23 +1,54 @@
 // instruments.js
 // Loads instrument/exchange data for dropdowns and datalists
 const nameTokenMap = {};
-document.addEventListener('DOMContentLoaded', function() {
-    fetch('/api/instruments/exchanges')
+
+function loadNames() {
+    const ex = document.getElementById('exchange-select').value;
+    const type = document.getElementById('type-select').value;
+    fetch(`/api/instruments/names?exchange=${ex}&type=${type}`)
         .then(r => r.json())
         .then(list => {
-            const sel = document.getElementById('exchange-select');
-            sel.innerHTML = list.map(e => `<option value="${e}">${e}</option>`).join('');
-        });
-    fetch('/api/instruments/names')
-        .then(r => r.json())
-        .then(list => {
+            console.debug('Loaded names', list);
             const dl = document.getElementById('name-list');
             dl.innerHTML = '';
-            list.forEach(item => {
+            for (const item of list) {
                 nameTokenMap[item.name] = item.instrumentToken;
                 const opt = document.createElement('option');
                 opt.value = item.name;
                 dl.appendChild(opt);
-            });
+            }
         });
+}
+
+function loadTypes() {
+    const ex = document.getElementById('exchange-select').value;
+    fetch(`/api/instruments/types?exchange=${ex}`)
+        .then(r => r.json())
+        .then(list => {
+            console.debug('Loaded types', list);
+            const sel = document.getElementById('type-select');
+            sel.innerHTML = list.map(t => `<option value="${t}">${t}</option>`).join('');
+            loadNames();
+        });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    fetch('/api/instruments/exchanges')
+        .then(r => r.json())
+        .then(list => {
+            console.debug('Loaded exchanges', list);
+            const sel = document.getElementById('exchange-select');
+            sel.innerHTML = list.map(e => `<option value="${e}">${e}</option>`).join('');
+            loadTypes();
+        });
+    document.getElementById('exchange-select').addEventListener('change', loadTypes);
+    document.getElementById('type-select').addEventListener('change', loadNames);
+    document.getElementById('refresh-btn').addEventListener('click', () => {
+        const ex = document.getElementById('exchange-select').value;
+        fetch(`/api/instruments/${ex}`, { method: 'POST' })
+            .then(() => {
+                console.info('Refresh complete for', ex);
+                loadTypes();
+            });
+    });
 });

--- a/src/main/resources/static/js/orders.js
+++ b/src/main/resources/static/js/orders.js
@@ -1,0 +1,39 @@
+// orders.js
+// Handles placing orders via REST API
+
+document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('order-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        const name = document.getElementById('order-name').value;
+        const token = window.nameTokenMap ? window.nameTokenMap[name] : undefined;
+        const qty = document.getElementById('order-qty').value;
+        const price = document.getElementById('order-price').value;
+        const side = document.getElementById('order-side').value;
+        if (!name || !qty) { return; }
+        const payload = {
+            tradingsymbol: name,
+            instrumentToken: token,
+            exchange: document.getElementById('exchange-select').value,
+            quantity: parseInt(qty, 10),
+            price: price ? parseFloat(price) : null,
+            transactionType: side
+        };
+        console.info('Submitting order', payload);
+        fetch('/api/orders', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        })
+        .then(r => r.json())
+        .then(data => {
+            console.debug('Order response', data);
+            document.getElementById('order-result').innerText = 'Order placed: ' + data.orderId;
+        })
+        .catch(err => {
+            console.error('Order failed', err);
+            document.getElementById('order-result').innerText = 'Order failed';
+        });
+    });
+});

--- a/src/main/resources/static/js/ticker.js
+++ b/src/main/resources/static/js/ticker.js
@@ -4,10 +4,12 @@ let ws;
 function connectWebSocket() {
     ws = new WebSocket('ws://localhost:8080/ws/ticker');
     ws.onopen = () => {
+        console.info('WebSocket opened');
         document.getElementById('ticker-table-container').innerHTML = '<p>Connected. Waiting for data...</p>';
     };
     ws.onmessage = (event) => {
         let data = JSON.parse(event.data);
+        console.debug('Received ticks', data);
         let html = '<table style="width:100%;margin-top:16px;"><tr><th>Token</th><th>Price</th><th>Timestamp</th></tr>';
         data.forEach(tick => {
             html += `<tr><td>${tick.token}</td><td>${tick.price}</td><td>${tick.timestamp}</td></tr>`;
@@ -16,6 +18,7 @@ function connectWebSocket() {
         document.getElementById('ticker-table-container').innerHTML = html;
     };
     ws.onclose = () => {
+        console.warn('WebSocket closed');
         document.getElementById('ticker-table-container').innerHTML = '<p>WebSocket disconnected.</p>';
     };
 }
@@ -24,10 +27,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // Connect WebSocket
     let ws = new WebSocket('ws://localhost:8080/ws/ticker');
     ws.onopen = () => {
+        console.info('WebSocket opened');
         document.getElementById('ticker-table-container').innerHTML = '<p>Connected. Waiting for data...</p>';
     };
     ws.onmessage = (event) => {
         let data = JSON.parse(event.data);
+        console.debug('Received ticks', data);
         let html = '<table style="width:100%;margin-top:16px;"><tr><th>Token</th><th>Price</th><th>Timestamp</th></tr>';
         data.forEach(tick => {
             html += `<tr><td>${tick.token}</td><td>${tick.price}</td><td>${tick.timestamp}</td></tr>`;
@@ -36,6 +41,7 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('ticker-table-container').innerHTML = html;
     };
     ws.onclose = () => {
+        console.warn('WebSocket closed');
         document.getElementById('ticker-table-container').innerHTML = '<p>WebSocket disconnected.</p>';
     };
 
@@ -43,6 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
     fetch('/api/ticker/subscriptions', { credentials: 'include' })
         .then(res => res.json())
         .then(data => {
+            console.debug('Current subscriptions', data);
             if (Array.isArray(data) && data.length > 0) {
                 let html = '<ul>';
                 data.forEach(token => {

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -40,12 +40,28 @@
             <h2>Subscribe Instrument</h2>
             <form id="api-action-form" style="margin-bottom:16px;">
                 <select id="exchange-select" style="padding:8px;border-radius:4px;border:1px solid #ccc;"></select>
-                <input type="text" id="api-input" list="name-list" placeholder="Instrument name" style="padding:8px;width:60%;border-radius:4px;border:1px solid #ccc;">
+                <select id="type-select" style="padding:8px;border-radius:4px;border:1px solid #ccc;"></select>
+                <input type="text" id="api-input" list="name-list" placeholder="Instrument name" style="padding:8px;width:40%;border-radius:4px;border:1px solid #ccc;">
                 <datalist id="name-list"></datalist>
                 <button type="submit">Subscribe Ticker</button>
+                <button type="button" id="refresh-btn" style="background:#3498db;margin-left:8px;">Refresh</button>
             </form>
             <button id="disconnect-btn" style="background:#888;">Disconnect Ticker</button>
             <div id="api-action-result" style="margin-top:16px;"></div>
+        </div>
+        <div id="order-row" style="margin-top:40px;">
+            <h2>Place Order</h2>
+            <form id="order-form" style="margin-bottom:16px;">
+                <input type="text" id="order-name" list="name-list" placeholder="Instrument name" style="padding:8px;width:40%;border-radius:4px;border:1px solid #ccc;">
+                <input type="number" id="order-qty" placeholder="Qty" style="padding:8px;width:80px;border-radius:4px;border:1px solid #ccc;">
+                <input type="number" step="0.01" id="order-price" placeholder="Price" style="padding:8px;width:100px;border-radius:4px;border:1px solid #ccc;">
+                <select id="order-side" style="padding:8px;border-radius:4px;border:1px solid #ccc;">
+                    <option value="BUY">BUY</option>
+                    <option value="SELL">SELL</option>
+                </select>
+                <button type="submit">Submit Order</button>
+            </form>
+            <div id="order-result" style="margin-top:16px;"></div>
         </div>
         <div id="ticker-row">
             <h2>Live Ticker Feed</h2>
@@ -59,6 +75,7 @@
     <script src="/js/portfolio.js"></script>
     <script src="/js/instruments.js"></script>
     <script src="/js/ticker.js"></script>
+    <script src="/js/orders.js"></script>
     <script src="/js/ui.js"></script>
     <!-- End modular JS includes -->
     <script th:inline="javascript">

--- a/src/test/java/org/mandrin/rain/broker/controller/InstrumentControllerTest.java
+++ b/src/test/java/org/mandrin/rain/broker/controller/InstrumentControllerTest.java
@@ -48,9 +48,19 @@ class InstrumentControllerTest {
         InstrumentRepository.NameTokenView view = mock(InstrumentRepository.NameTokenView.class);
         when(view.getInstrumentToken()).thenReturn(1L);
         when(view.getName()).thenReturn("ABC");
-        when(service.listNameTokens()).thenReturn(List.of(view));
-        mockMvc.perform(get("/api/instruments/names"))
+        when(service.listNames("NSE", "EQ")).thenReturn(List.of(view));
+        mockMvc.perform(get("/api/instruments/names")
+                .param("exchange", "NSE")
+                .param("type", "EQ"))
                 .andExpect(status().isOk());
-        verify(service).listNameTokens();
+        verify(service).listNames("NSE", "EQ");
+    }
+
+    @Test
+    void types_ShouldReturnList() throws Exception {
+        when(service.listInstrumentTypes("NSE")).thenReturn(List.of("EQ"));
+        mockMvc.perform(get("/api/instruments/types").param("exchange", "NSE"))
+                .andExpect(status().isOk());
+        verify(service).listInstrumentTypes("NSE");
     }
 }

--- a/src/test/java/org/mandrin/rain/broker/controller/OrderControllerTest.java
+++ b/src/test/java/org/mandrin/rain/broker/controller/OrderControllerTest.java
@@ -1,0 +1,48 @@
+package org.mandrin.rain.broker.controller;
+
+import org.junit.jupiter.api.Test;
+import org.mandrin.rain.broker.model.TradeOrder;
+import org.mandrin.rain.broker.service.OrderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OrderController.class)
+class OrderControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrderService orderService;
+
+    @Test
+    void place_ShouldReturnOk() throws Exception {
+        TradeOrder o = new TradeOrder();
+        o.setOrderId("1");
+        when(orderService.placeOrder(any(), any())).thenReturn(o);
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("kite_access_token", "t");
+        mockMvc.perform(post("/api/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+                .session(session))
+                .andExpect(status().isOk());
+        verify(orderService).placeOrder(any(), any());
+    }
+
+    @Test
+    void list_ShouldReturnOk() throws Exception {
+        when(orderService.listOrders()).thenReturn(java.util.List.of());
+        mockMvc.perform(get("/api/orders"))
+                .andExpect(status().isOk());
+        verify(orderService).listOrders();
+    }
+}

--- a/src/test/java/org/mandrin/rain/broker/controller/TickerControllerTest.java
+++ b/src/test/java/org/mandrin/rain/broker/controller/TickerControllerTest.java
@@ -6,12 +6,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mandrin.rain.broker.service.SubscriptionService;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
 
 @WebMvcTest(TickerController.class)
 class TickerControllerTest {
@@ -20,6 +25,9 @@ class TickerControllerTest {
 
     @Autowired
     private KiteTickerService tickerService;
+
+    @MockBean
+    private SubscriptionService subscriptionService;
 
     @TestConfiguration
     static class KiteTickerServiceTestConfig {
@@ -50,6 +58,15 @@ class TickerControllerTest {
                 .session(session))
                 .andExpect(MockMvcResultMatchers.status().isOk());
         org.junit.jupiter.api.Assertions.assertTrue(((KiteTickerServiceTestConfig.TestKiteTickerService)tickerService).subscribeCalled);
+        verify(subscriptionService).saveAll(anyList());
+    }
+
+    @Test
+    void subscriptions_ShouldReturnOk() throws Exception {
+        when(subscriptionService.listTokens()).thenReturn(List.of(1L));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/ticker/subscriptions"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+        verify(subscriptionService).listTokens();
     }
 
     @Test

--- a/src/test/java/org/mandrin/rain/broker/service/InstrumentServiceTest.java
+++ b/src/test/java/org/mandrin/rain/broker/service/InstrumentServiceTest.java
@@ -59,4 +59,29 @@ class InstrumentServiceTest {
         assertEquals(1, result.size());
         verify(repo).findNameTokenAll();
     }
+
+    @Test
+    void listInstrumentTypes_ShouldDelegateToRepo() {
+        ExchangeFunction fn = mock(ExchangeFunction.class);
+        WebClient client = WebClient.builder().exchangeFunction(fn).build();
+        InstrumentRepository repo = mock(InstrumentRepository.class);
+        when(repo.findDistinctInstrumentType("NSE")).thenReturn(List.of("EQ"));
+        InstrumentService service = new InstrumentService(client, repo);
+        List<String> result = service.listInstrumentTypes("NSE");
+        assertEquals(1, result.size());
+        verify(repo).findDistinctInstrumentType("NSE");
+    }
+
+    @Test
+    void listNames_ShouldDelegate() {
+        ExchangeFunction fn = mock(ExchangeFunction.class);
+        WebClient client = WebClient.builder().exchangeFunction(fn).build();
+        InstrumentRepository repo = mock(InstrumentRepository.class);
+        InstrumentRepository.NameTokenView view = mock(InstrumentRepository.NameTokenView.class);
+        when(repo.findNameToken("NSE", "EQ")).thenReturn(List.of(view));
+        InstrumentService service = new InstrumentService(client, repo);
+        List<InstrumentRepository.NameTokenView> result = service.listNames("NSE", "EQ");
+        assertEquals(1, result.size());
+        verify(repo).findNameToken("NSE", "EQ");
+    }
 }

--- a/src/test/java/org/mandrin/rain/broker/service/OrderServiceTest.java
+++ b/src/test/java/org/mandrin/rain/broker/service/OrderServiceTest.java
@@ -1,0 +1,56 @@
+package org.mandrin.rain.broker.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import org.mandrin.rain.broker.config.KiteConstants;
+import org.mandrin.rain.broker.model.TradeOrder;
+import org.mandrin.rain.broker.repository.TradeOrderRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class OrderServiceTest {
+    @Test
+    void placeOrder_ShouldCallApiAndPersist() {
+        ExchangeFunction fn = mock(ExchangeFunction.class);
+        ClientResponse resp = ClientResponse.create(HttpStatus.OK)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .body("{\"data\":{\"order_id\":\"1\"}}")
+                .build();
+        when(fn.exchange(any(ClientRequest.class))).thenReturn(Mono.just(resp));
+        WebClient client = WebClient.builder().exchangeFunction(fn).build();
+        TradeOrderRepository repo = mock(TradeOrderRepository.class);
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        OrderService service = new OrderService(client, repo);
+        setField(service, "apiKey", "key");
+        HttpSession session = mock(HttpSession.class);
+        when(session.getAttribute(KiteConstants.KITE_ACCESS_TOKEN_SESSION)).thenReturn("token");
+        TradeOrder req = new TradeOrder();
+        req.setTradingsymbol("ABC");
+        req.setExchange("NSE");
+        req.setTransactionType("BUY");
+        req.setQuantity(1);
+        TradeOrder saved = service.placeOrder(session, req);
+        assertEquals("1", saved.getOrderId());
+        verify(repo).save(any());
+        verify(fn).exchange(any(ClientRequest.class));
+    }
+
+    private void setField(Object target, String field, Object value) {
+        try {
+            java.lang.reflect.Field f = target.getClass().getDeclaredField(field);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/mandrin/rain/broker/service/SubscriptionServiceTest.java
+++ b/src/test/java/org/mandrin/rain/broker/service/SubscriptionServiceTest.java
@@ -1,0 +1,41 @@
+package org.mandrin.rain.broker.service;
+
+import org.junit.jupiter.api.Test;
+import org.mandrin.rain.broker.model.Subscription;
+import org.mandrin.rain.broker.model.Instrument;
+import org.mandrin.rain.broker.repository.InstrumentRepository;
+import org.mandrin.rain.broker.repository.SubscriptionRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SubscriptionServiceTest {
+    @Test
+    void saveAll_ShouldIgnoreDuplicates() {
+        SubscriptionRepository repo = mock(SubscriptionRepository.class);
+        InstrumentRepository instrumentRepo = mock(InstrumentRepository.class);
+        when(repo.existsByInstrumentToken(1L)).thenReturn(false);
+        Instrument inst = new Instrument();
+        inst.setTradingsymbol("ABC");
+        when(instrumentRepo.findById(1L)).thenReturn(Optional.of(inst));
+        SubscriptionService service = new SubscriptionService(repo, instrumentRepo);
+        service.saveAll(List.of(1L));
+        verify(repo).save(any(Subscription.class));
+    }
+
+    @Test
+    void listTokens_ShouldReturnAll() {
+        SubscriptionRepository repo = mock(SubscriptionRepository.class);
+        InstrumentRepository instrumentRepo = mock(InstrumentRepository.class);
+        Subscription sub = new Subscription();
+        sub.setInstrumentToken(1L);
+        when(repo.findAll()).thenReturn(List.of(sub));
+        SubscriptionService service = new SubscriptionService(repo, instrumentRepo);
+        List<Long> list = service.listTokens();
+        assertEquals(1, list.size());
+        assertEquals(1L, list.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- switch `OrderService` to use WebClient instead of RestTemplate
- add Subscription entity, repository and service
- persist subscriptions when subscribing via ticker controller
- expose new `/api/ticker/subscriptions` endpoint
- provide instrument type and name queries and refresh button in UI
- update README and tests for new functionality
- add global exception handling and extensive logging
- reduce boilerplate using Lombok and slf4j across models and services

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686096287c1c83249a662f55568efda9